### PR TITLE
Reduce complexity, and make a .deb

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,71 +25,38 @@ So I stuck together a little script that has helped a lot, for me. The debug-eve
 
 .. but it left the touchpad in an odd state where you had to lift your finger and put it back down again for it to start accepting motion - something seems broken. The debug-events monitor does not have that issue.
 
-The script consumes very little CPU, and works fine for me. If you want to use it, you'll have to find your path to enabling/disabling your touchpad.
+The script consumes very little CPU, and works fine for me. It discovers the touchpad from `/proc/bus/input/devices`, then inhibits it through `/sys/class/input/inputN/inhibited`, so there is no Dell-specific sysfs path to paste into the script.
 
-To do so:
-
-1. Search the device list for Touch or Touchpad or 'ouch':
-```
-cat /proc/bus/input/devices | grep -A10 -B1 ouch
-```
-
-Example output:
+## Build a deb
 
 ```
-markumina@markxps:~/Documents/hackpad$ cat /proc/bus/input/devices | grep -A10 -B1 ouch
-I: Bus=0018 Vendor=0488 Product=1072 Version=0100
-N: Name="VEN_0488:00 0488:1072 Touchpad"
-P: Phys=i2c-VEN_0488:00
-S: Sysfs=/devices/pci0000:00/0000:00:15.2/i2c_designware.1/i2c-2/i2c-VEN_0488:00/0018:0488:1072.0002/input/input17
-U: Uniq=
-H: Handlers=mouse2 event7 
-B: PROP=5
-B: EV=1b
-B: KEY=e520 10000 0 0 0 0
-B: ABS=2e0800000000003
-B: MSC=20
-```
-So my path is:
-```
-/devices/pci0000:00/0000:00:15.2/i2c_designware.1/i2c-2/i2c-VEN_0488:00/0018:0488:1072.0002/input/input17
+./build-deb.sh
 ```
 
-3. Take path above and:
-   a. Add prefix /sys/
-   b. Remove the input17 (or inputxx - whatever number it may be, it's dynamic so the script ignores it)
-   c. Place this path in hackpad.sh `TOUCHPAD_DEVICE`, making sure to keep: "/${TOUCHPAD_DEVICE}/inhibited" at the end
-
-For me that results in:
+That creates:
 
 ```
-TOUCHPAD_DEVICE="/sys/devices/pci0000:00/0000:00:15.2/i2c_designware.1/i2c-2/i2c-VEN_0488:00/0018:0488:1072.0002/input/${TOUCHPAD_DEVICE}/inhibited"
+dist/hackpad_0.1.0_all.deb
 ```
 
-4. sudo vi /etc/systemd/system/hackpad.service
-
-5. Paste contents below:
-```
-[Unit]
-Description=Hackpad Touchpad Management Script
-
-[Service]
-ExecStart=/opt/hackpad/hackpad.sh
-Restart=always
-RestartSec=5  # Optional: time to wait before restarting (in seconds)
-
-[Install]
-WantedBy=multi-user.target
-```
-
-6. Place your hackpad.sh file in /opt/hackpad.sh
-
-7. Enable the service and reload:
+Install it with:
 
 ```
-sudo systemctl daemon-reload
-sudo systemctl enable hackpad.service
-sudo systemctl start hackpad.service
+sudo apt install ./dist/hackpad_0.1.0_all.deb
+```
+
+The package installs:
+
+```
+/opt/hackpad/hackpad.sh
+/etc/systemd/system/hackpad.service
+```
+
+The package post-install step reloads systemd, enables `hackpad.service`, and restarts it.
+
+Check status with:
+
+```
 systemctl status hackpad.service
 ```
 Check that it restarted automatically on reboot by typing while attempting to use the trackpad.
@@ -112,5 +79,4 @@ Check that it restarted automatically on reboot by typing while attempting to us
    E. Run `sudo reboot now`
 
 Hit me up: mark.umina at gmail dot com.
-
 

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PACKAGE="hackpad"
+VERSION="${VERSION:-0.1.0}"
+ARCHITECTURE="all"
+
+REPO_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/${PACKAGE}-deb.XXXXXX")"
+OUT_DIR="${REPO_DIR}/dist"
+OUT_FILE="${OUT_DIR}/${PACKAGE}_${VERSION}_${ARCHITECTURE}.deb"
+
+cleanup() {
+    rm -rf "$BUILD_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p \
+    "$BUILD_DIR/DEBIAN" \
+    "$BUILD_DIR/opt/hackpad" \
+    "$BUILD_DIR/etc/systemd/system" \
+    "$BUILD_DIR/usr/share/doc/hackpad" \
+    "$OUT_DIR"
+
+install -m 0755 "$REPO_DIR/hackpad.sh" "$BUILD_DIR/opt/hackpad/hackpad.sh"
+install -m 0644 "$REPO_DIR/hackpad.service" "$BUILD_DIR/etc/systemd/system/hackpad.service"
+install -m 0644 "$REPO_DIR/README.md" "$BUILD_DIR/usr/share/doc/hackpad/README.md"
+
+cat > "$BUILD_DIR/DEBIAN/control" <<EOF
+Package: ${PACKAGE}
+Version: ${VERSION}
+Section: utils
+Priority: optional
+Architecture: ${ARCHITECTURE}
+Depends: bash, libinput-tools, systemd
+Maintainer: Mark Umina <mark.umina@gmail.com>
+Description: Touchpad inhibition helper for typing on Wayland
+ Hackpad temporarily inhibits the touchpad after keyboard input so palm taps
+ do not become accidental clicks while typing.
+EOF
+
+cat > "$BUILD_DIR/DEBIAN/conffiles" <<EOF
+/etc/systemd/system/hackpad.service
+EOF
+
+cat > "$BUILD_DIR/DEBIAN/postinst" <<'EOF'
+#!/bin/sh
+set -e
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+    systemctl enable hackpad.service || true
+    systemctl restart hackpad.service || true
+fi
+
+exit 0
+EOF
+
+cat > "$BUILD_DIR/DEBIAN/prerm" <<'EOF'
+#!/bin/sh
+set -e
+
+if [ "$1" = "remove" ] || [ "$1" = "deconfigure" ]; then
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl stop hackpad.service || true
+        systemctl disable hackpad.service || true
+    fi
+fi
+
+exit 0
+EOF
+
+cat > "$BUILD_DIR/DEBIAN/postrm" <<'EOF'
+#!/bin/sh
+set -e
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+fi
+
+exit 0
+EOF
+
+chmod 0755 \
+    "$BUILD_DIR/DEBIAN/postinst" \
+    "$BUILD_DIR/DEBIAN/prerm" \
+    "$BUILD_DIR/DEBIAN/postrm"
+
+find "$BUILD_DIR" -type d -exec chmod 0755 {} +
+
+dpkg-deb --build --root-owner-group "$BUILD_DIR" "$OUT_FILE"
+echo "$OUT_FILE"

--- a/hackpad.service
+++ b/hackpad.service
@@ -6,7 +6,7 @@ After=multi-user.target
 ExecStart=/opt/hackpad/hackpad.sh
 Restart=always
 User=root
+RuntimeDirectory=hackpad
 
 [Install]
 WantedBy=multi-user.target
-

--- a/hackpad.sh
+++ b/hackpad.sh
@@ -5,7 +5,15 @@
 USER_NAME="markumina"
 
 # Extract the input<number> path dynamically from /proc/bus/input/devices
-TOUCHPAD_DEVICE=$(cat /proc/bus/input/devices | grep -A10 -B1 ouch | grep -oP "input\d+" | head -n 1)
+TOUCHPAD_DEVICE=$(awk '
+    /^N: Name=/ && tolower($0) ~ /touchpad/ { in_touchpad = 1; next }
+    in_touchpad && /^S: Sysfs=/ {
+        sub(/^S: Sysfs=.*\/input\//, "")
+        print
+        exit
+    }
+    /^$/ { in_touchpad = 0 }
+' /proc/bus/input/devices)
 
 # Check if the path was found
 if [ -z "$TOUCHPAD_DEVICE" ]; then
@@ -14,13 +22,20 @@ if [ -z "$TOUCHPAD_DEVICE" ]; then
 fi
 
 # Define the full path to the "inhibited" file for the touchpad
-TOUCHPAD_DEVICE="/sys/devices/pci0000:00/0000:00:15.2/i2c_designware.1/i2c-2/i2c-VEN_0488:00/0018:0488:1072.0002/input/${TOUCHPAD_DEVICE}/inhibited"
+TOUCHPAD_DEVICE="/sys/class/input/${TOUCHPAD_DEVICE}/inhibited"
+
+if [ ! -f "$TOUCHPAD_DEVICE" ]; then
+    echo "Error: Touchpad inhibited path not found: $TOUCHPAD_DEVICE"
+    exit 1
+fi
 
 # Dump it for debug
 echo "TOUCHPAD_DEVICE is set to: $TOUCHPAD_DEVICE"
 
-# Temporary file to store the state of touched_while_in_delay
-TOUCHED_FILE="/tmp/touched_while_in_delay.txt"
+# Runtime file to store the state of touched_while_in_delay
+RUNTIME_DIR="${RUNTIME_DIRECTORY:-/run/hackpad}"
+mkdir -p "$RUNTIME_DIR"
+TOUCHED_FILE="$RUNTIME_DIR/touched_while_in_delay"
 
 # Function to disable the touchpad
 disable_touchpad() {


### PR DESCRIPTION
This pull request introduces a new Debian package build system for the project, significantly improving installation and service management. It also refines the touchpad device detection logic and updates the documentation to match the new packaging approach.

**Debian packaging and installation improvements:**

* Added a new `build-deb.sh` script to automate building a `.deb` package, including all necessary files, metadata, and systemd service integration. The package post-install step reloads systemd, enables, and restarts the service automatically.
* Updated the `hackpad.service` unit file to use `RuntimeDirectory=hackpad` for improved runtime file management.

**Touchpad detection and runtime behavior:**

* Refactored touchpad device detection in `hackpad.sh` to reliably parse `/proc/bus/input/devices` using `awk`, and updated the inhibited file path to use `/sys/class/input/${TOUCHPAD_DEVICE}/inhibited`. Added error handling if the path is not found. [[1]](diffhunk://#diff-a7363d3174c2253da3afe64741d376eb9c7740f597d8350e7b1cc89278d69442L8-R16) [[2]](diffhunk://#diff-a7363d3174c2253da3afe64741d376eb9c7740f597d8350e7b1cc89278d69442L17-R38)
* Changed the runtime state file location to `/run/hackpad` (or a configurable runtime directory) for better alignment with systemd conventions.

**Documentation updates:**

* Overhauled the `README.md` to describe the new build and installation process, removing manual steps and reflecting the improved device discovery and service setup. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-L92) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L116)